### PR TITLE
Fix: Make sure test file x can be removed after chmod-ing it.

### DIFF
--- a/tests/test_core/test_open_file.py
+++ b/tests/test_core/test_open_file.py
@@ -59,9 +59,19 @@ class OpenFail(base.TestCase):
         document = self.createFile('x', 'the text')
         core.workspace().closeDocument(document)
 
-        os.chmod('x', 0)
-
-        self._runTest('x', "Don't have the access")
+        # On Windows (possibly Unix -- not tested), the file x below cannot be
+        # erased after the chmod, making future tests using x fail. So, be sure
+        # to chmod it back to the old permissions after the test runs. Note that,
+        # per the `stat docs <https://docs.python.org/2/library/os.html#os.stat>`_,
+        # stat returns lots of info; the only thing we care about is the file
+        # permissions in st_mode, which `chmod
+        # <https://docs.python.org/2/library/os.html#os.chmod>`_ uses.
+        s = os.stat('x').st_mode
+        try:
+            os.chmod('x', 0)
+            self._runTest('x', "Don't have the access")
+        finally:
+            os.chmod('x', s)
 
 
 class Loop(base.TestCase):


### PR DESCRIPTION
On Windows, the first run of test_open_file works (sort of), but the second fails because one of the test files (x) can't be removed. This fix allows x to be removed after each test run, so the tests succeed when run multiple times.

```
C:\Users\bjones\Documents\enki_all\enki\tests\test_core>python -m unittest -v test_open_file
test_1 (test_open_file.Loop) ... Traceback (most recent call last):
  File "test_open_file.py", line 72, in func
AttributeError: 'NoneType' object has no attribute 'addAction'
ok
test_2 (test_open_file.Loop) ... Traceback (most recent call last):
  File "test_open_file.py", line 85, in func
AttributeError: 'NoneType' object has no attribute 'setCurrentDocument'
ok
test_1 (test_open_file.OpenFail) ... ok
test_2 (test_open_file.OpenFail) ... ok
test_3 (test_open_file.OpenFail) ... ok
test_4 (test_open_file.OpenFail) ... ok
test_1 (test_open_file.Test) ... ok

----------------------------------------------------------------------
Ran 7 tests in 40.429s

OK

C:\Users\bjones\Documents\enki_all\enki\tests\test_core>python -m unittest -v test_open_file
test_1 (test_open_file.Loop) ... Traceback (most recent call last):
  File "test_open_file.py", line 72, in func
AttributeError: 'NoneType' object has no attribute 'addAction'
ok
test_2 (test_open_file.Loop) ... ERROR
test_1 (test_open_file.OpenFail) ... ok
test_2 (test_open_file.OpenFail) ... ok
test_3 (test_open_file.OpenFail) ... ERROR
test_4 (test_open_file.OpenFail) ... ERROR
test_1 (test_open_file.Test) ... ok

======================================================================
ERROR: test_2 (test_open_file.Loop)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_open_file.py", line 81, in test_2
  File "C:\Users\bjones\Documents\enki_all\enki\tests\test_core\..\base.py", lin
e 207, in createFile
    with open(path, 'wb') as file_:
IOError: [Errno 13] Permission denied: 'c:\\users\\bjones\\appdata\\local\\temp\
\enki-tests\\x'

======================================================================
ERROR: test_3 (test_open_file.OpenFail)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_open_file.py", line 47, in test_3
  File "C:\Users\bjones\Documents\enki_all\enki\tests\test_core\..\base.py", lin
e 207, in createFile
    with open(path, 'wb') as file_:
IOError: [Errno 13] Permission denied: 'c:\\users\\bjones\\appdata\\local\\temp\
\enki-tests\\x'

======================================================================
ERROR: test_4 (test_open_file.OpenFail)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_open_file.py", line 59, in test_4
  File "C:\Users\bjones\Documents\enki_all\enki\tests\test_core\..\base.py", lin
e 207, in createFile
    with open(path, 'wb') as file_:
IOError: [Errno 13] Permission denied: 'c:\\users\\bjones\\appdata\\local\\temp\
\enki-tests\\x'

----------------------------------------------------------------------
Ran 7 tests in 20.350s

FAILED (errors=3)
```
