### PR TITLE
Background sync

### DIFF
--- a/enki/lib/future.py
+++ b/enki/lib/future.py
@@ -287,8 +287,8 @@ class AsyncPoolController(AsyncAbstractController):
     def __init__(self,
       # A number *n* to create a pool of *n* simple threads, where each thread
       # lacks an event loop, so that it can emit but not receive signals.
-      # This means that ``g`` may **not** be run in a thread, without
-      # manually adding a event loop. If *n* < 1, the global thread pool
+      # This means that ``g`` may **not** be run in a thread of this pool,
+      # without manually adding a event loop. If *n* < 1, the global thread pool
       # is used.
       maxThreadCount,
 
@@ -297,21 +297,21 @@ class AsyncPoolController(AsyncAbstractController):
 
         AsyncAbstractController.__init__(self, parent)
         if maxThreadCount < 1:
-            self._threadPool = QThreadPool.globalInstance()
+            self.threadPool = QThreadPool.globalInstance()
         else:
-            self._threadPool = QThreadPool()
-            self._threadPool.setMaxThreadCount(maxThreadCount)
+            self.threadPool = QThreadPool()
+            self.threadPool.setMaxThreadCount(maxThreadCount)
 
     # |_start|
     def _start(self, future):
         # Asynchronously invoke ``f``.
         apw = _AsyncPoolWorker(future)
-        self._threadPool.start(apw)
+        self.threadPool.start(apw)
 
     # |del_|
     def _del(self):
-        self._threadPool.waitForDone()
-        del self._threadPool
+        self.threadPool.waitForDone()
+        del self.threadPool
 
 # AsyncController
 # ---------------
@@ -419,8 +419,10 @@ class Future(object):
             # exception doesn't preserve the full traceback. Likewise, ``raise
             # self._exc_info`` provides only a limited tracebacak.
             #
-            # The mapping: One form of `raise <https://docs.python.org/2/reference/simple_stmts.html#raise>`_
-            # expects ``instance, None, traceback``. `sys.exc_info() <https://docs.python.org/2/library/sys.html#sys.exc_info>`_
+            # The mapping: One form of `raise
+            # <https://docs.python.org/2/reference/simple_stmts.html#raise>`_
+            # expects ``instance, None, traceback``. `sys.exc_info()
+            # <https://docs.python.org/2/library/sys.html#sys.exc_info>`_
             # produces ``type, value, traceback`` where type is the exception
             # type of the exception being handled, value is a class instance,
             # and traceback is the desired trackback to report.

--- a/enki/lib/future.py
+++ b/enki/lib/future.py
@@ -1,0 +1,438 @@
+# .. -*- coding: utf-8 -*-
+#
+# ****************************
+# future.py - Futures for PyQt
+# ****************************
+# The idea: create a simple class that encapsulates a thread or thread pool and
+# uses it to run a function asynchronously. For example, to run a function
+# ``f(a, b)``, then invoke a callback ``g`` with the return value provided by
+# ``f`` stored in a class::
+#
+#   app = QApplication(sys.argv)
+#   ac = AsyncController('QThread', app)
+#   def g(future):
+#     result = future.result
+#     ...code to process result, the returned tuple resulting from calling ``f``...
+#   ac.start(g, f, a, b)
+#
+# This is *almost* like::
+#
+#   result = f(a, b)
+#   g(result)
+#
+# except that ``f`` is run in a separate thread and ``g`` isn't invoked until
+# ``f`` completes.
+#
+# To do
+# =====
+# - Make job cancellation change state after the current job completes,
+#   instead of waiting until the cancelled job would have been run.
+#
+# Imports
+# =======
+# Library imports
+# ---------------
+import sys, time
+#
+# Third-party imports
+# -------------------
+from PyQt4.QtGui import QApplication
+from PyQt4.QtCore import QThread, pyqtSignal, QObject, QTimer, QRunnable, \
+    QThreadPool
+#
+# Local imports
+# -------------
+# None.
+#
+# Implementation
+# ==============
+# The ``AsyncController`` class first wraps a function to be executed along
+# with the neceesary state in a ``Future`` class. Next, it schedules this
+# class to be executed by the ``_AsyncWorker`` in a thread it creates or in the
+# ``_AsyncPoolWorker`` pool it uses, then passes results from that invocation
+# back to the thread in which the ``asyncController.start()`` method was called.
+#
+# AsyncController
+# ---------------
+# This class provides a simpe user interface to start up a thread or thread
+# pool, then submit jobs to it. This class **must** be shut down properly
+# before application exit; see the cleanup_ section for details.
+class AsyncController(QObject):
+    # Create a worker thread or thread pool.
+    def __init__(self,
+      # * 'QThread' to create a single QThread with an event loop, enabling it
+      #   to both emit and receive signals -- meaning that ``g`` may be run
+      #   in this created thread.
+      # * A number *n* to create a pool of *n* simple threads, where each thread
+      #   lacks an event loop, so that it can emit but not receive signals.
+      #   This means that ``g`` may **not** be run in a thread, without
+      #   manually adding a event loop. If *n* < 1, the global thread pool
+      #   is used.
+      qThreadOrThreadPool,
+
+      # The parent of this object, if it exists. Selecting an object as
+      # a parent guarantees that this class instance will be properly
+      # finalized when the parent is deleted. If parent is None, then the
+      # ``del_()`` method **MUST** be called before the program exits.
+      # See the cleanup_ section below for more information.
+      parent=None):
+
+        QObject.__init__(self, parent)
+        self.isAlive = True
+
+        # Ask the parent and QApplication for a signal before they're
+        # destroyed, so we can do cleanup.
+        if parent:
+            parent.destroyed.connect(self.onParentDestroyed)
+        QApplication.instance().destroyed.connect(self.onParentDestroyed)
+
+        # Create either a thread pool or a thread.
+        self._usePool = qThreadOrThreadPool != 'QThread'
+        if self._usePool:
+            if qThreadOrThreadPool < 1:
+                self._threadPool = QThreadPool.globalInstance()
+            else:
+                self._threadPool = QThreadPool()
+                self._threadPool.setMaxThreadCount(qThreadOrThreadPool)
+        else:
+            # Create a worker and a thread it runs in. This approach was
+            # inspired by  example given in the `QThread docs
+            # <http://qt-project.org/doc/qt-4.8/qthread.html>`_.
+
+            self._worker = _AsyncWorker()
+            self._workerThread = QThread()
+            # Attach the worker to the thread's event queue.
+            self._worker.moveToThread(self._workerThread)
+            # Hook up signals.
+            self._worker.startSignal.connect(self._worker.onStart)
+            # Everything is ready. Start the worker thread, so it will
+            # be ready for functions to run.
+            self._workerThread.start()
+
+    # Run ``future.result = f(*args, **kwargs)`` in a separate thread. When it
+    # completes, invoke ``g(future)``, if ``g`` is provided. Returns a ``Future``
+    # instance, which can be used to interact with ``f``.
+    #
+    def start(self,
+      # A result function which take one parameter, ``future``, which will be
+      # executed in the thread *t* from which this method was called, or None if
+      # no function should be invoked after ``f`` completes. **Important**: ``g``
+      # will **not** be invoked if the thread *t* does not provide an event
+      # loop -- such as a thread taken from the thread pool. See the
+      # constructor's ``qThreadOrThreadPool`` parameter for more information.
+      g,
+
+      # A function which will be executed in a separate thread. Note that:
+      #
+      # - Any exceptions raised in ``f`` will be caught, then re-raised in
+      #   ``g(future)`` when accessing ``future.result``.
+      # - **Very important**: The parameters to ``f`` must be immutable, or must
+      #   not change while ``f`` is executing. The same is true of the value
+      #   returned by ``f``.
+      f,
+
+      # Arguments used to invoke ``f``.
+      *args,
+
+      # Keyword arguments used to invoke ``f``.
+      **kwargs):
+
+        # Wrap ``f`` and associated data in a Future.
+        future = self._wrap(g, f, *args, **kwargs)
+        # Run it in another thread.
+        self._start(future)
+        return future
+
+    # Wrap ``f`` and ``g`` in a Future and return it. This and the following
+    # method are used to do testing.
+    def _wrap(self, g, f, *args, **kwargs):
+        # Wrap ``f`` and associated data in a class.
+        return Future(g, f, args, kwargs)
+
+    # Given a Future instance, run it in another thread.
+    def _start(self, future):
+        # Asynchronously invoke ``f``.
+        if self._usePool:
+            apw = _AsyncPoolWorker(future)
+            self._threadPool.start(apw)
+        else:
+            self._worker.startSignal.emit(future)
+#
+# Cleanup
+# ^^^^^^^
+# **Very important**: Before application exit, cleanup tasks in this class
+# **MUST** be performed. Otherwise, the code will print error messages and
+# probably crash. Options are:
+#
+# #. Use a context manager::
+#
+#      with AsyncController(qThreadOrThreadPool):
+#           ac.start(g, f, ...)
+#           ...do more work...
+#
+# #. Let Qt invoke cleanup by providing it a parent, thus including it in the
+#    object tree. The sample code at the top of thie file takes this approach.
+#    As a backup to this approach, this class will also destroy itself when
+#    the QApplication is destroyed.
+#
+# #. Finalize this instance if the Python destructor is invoked. Python does
+#    not guarantee that this will **ever** be invoked. Don't rely on it.
+#
+# #. Manually call ``asyncController.del_()`` when necessary. This is soooo
+#    easy to forget.
+#
+#
+# Context manager
+# """""""""""""""
+    # Provide a `context manager <https://docs.python.org/2/library/stdtypes.html#typecontextmanager>`_
+    # for Pythonic construction and cleanup.
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.del_()
+        # Pass any exceptions through.
+        return False
+#
+# Qt destructor
+# """""""""""""
+    # This is run shortly before this class's C++ destructor is invoked. It
+    # emulates a C++ destructor by freeing resources before the C++ class is
+    # destroyed.
+    def onParentDestroyed(self):
+        #print('onParentDestroyed')
+        self.del_()
+#
+# Destructor
+# """"""""""
+    # In case the above method wasn't called (parent wasn't provided to the
+    # constructor, typically), try to exit gracefully here.
+    def __del__(self):
+        self.del_()
+#
+# Manual
+# """"""
+    # Without calling this before the program exits, we get nasty crashes since
+    # the Python portion of the class is still alive. At a minimum, we see
+    # "QThread: Destroyed while thread is still running" messages.
+    #
+    # This is NOT thread-safe.
+    def del_(self):
+        # Only run this once.
+        if self.isAlive:
+            #print('shutdown')
+            self.isAlive = False
+            if self._usePool:
+                self._threadPool.waitForDone()
+                del self._threadPool
+            else:
+                # Now, shut down the thread the Worker runs in.
+                self._workerThread.quit()
+                self._workerThread.wait()
+                # Finally, detach (and probably garbage collect) the objects
+                # used by this class.
+                del self._worker
+                del self._workerThread
+#
+# Future
+# ------
+# The Future class holds all the information necessary to invoke ``f``
+# and return its results to ``g``.
+class Future(object):
+    # The possible states for an instance of this class.
+    STATE_WAITING, STATE_RUNNING, STATE_FINISHED, STATE_CANCELED = range(4)
+
+    def __init__(self,
+      # A function to invoke in the calling thread with the return value
+      # produced by  ``f``  If this is None, it will not be invoked.
+      g,
+      # A function which will be invoked in the worker thread / pool.
+      f,
+      # A list of arguments passed to ``f``.
+      args,
+      # A dict of keyword arguments passed to ``f``.
+      kwargs):
+
+        self._g = g
+        self._f = f
+        self._args = args
+        self._kwargs = kwargs
+
+        # State maintained by Future.
+        self._state = self.STATE_WAITING
+        self.signalInvoker = SignalInvoker()
+        self._requestCancel = False
+        self._result = None
+        self._exc_info = None
+
+        if self._g:
+            # Set up to invoke ``g`` in the current thread, if ``g`` was
+            # provided.
+            self.signalInvoker.doneSignal.connect(self.signalInvoker.onDoneSignal)
+
+    # Invoke ``f`` and emit its returned value.
+    def _invoke(self):
+        if self._requestCancel:
+            # Skip canceled callables.
+            self._state = self.STATE_CANCELED
+        else:
+            # Run the function, catching any exceptions.
+            self._state = self.STATE_RUNNING
+            try:
+                self._result = self._f(*self._args, **self._kwargs)
+            except:
+                # Save not just the exception, but also the traceback to provide
+                # better debugging info when this is re-raised in the calling
+                # thread.
+                self._exc_info = sys.exc_info()
+
+            # Report the results.
+            self._state = self.STATE_FINISHED
+            self.signalInvoker.doneSignal.emit(self)
+
+    # This method may be called from any thread; it requests that the execution
+    # of ``f`` be canceled.
+    def cancel(self):
+        self._requestCancel = True
+
+    # Return the result produced by invoking ``f``, or raise any exception which
+    # occurred in ``f``.
+    @property
+    def result(self):
+        if self._exc_info:
+            # Raise an exception which provides a trackback all the way into the
+            # line in ``f`` that caused the exception. Just re-raising the
+            # exception doesn't preserve the full traceback. Likewise, ``raise
+            # self._exc_info`` provides only a limited tracebacak.
+            #
+            # The mapping: One form of `raise <https://docs.python.org/2/reference/simple_stmts.html#raise>`_
+            # expects ``instance, None, traceback``. `sys.exc_info() <https://docs.python.org/2/library/sys.html#sys.exc_info>`_
+            # produces ``type, value, traceback`` where type is the exception
+            # type of the exception being handled, value is a class instance,
+            # and traceback is the desired trackback to report.
+            raise self._exc_info[1], None, self._exc_info[2]
+        else:
+            return self._result
+
+    # Make ``state`` a read-only property. It reflects the status of the
+    # callable it wraps.
+    @property
+    def state(self):
+        return self._state
+
+# A helper class to hold a signal and invoke ``g``. This can't be easily
+# incorporated into ``Future`` for several reasons:
+#
+# #. Any class inheriting from QObject, crossing threads, and without a parent
+#    gets destroyed by Qt. This is exactly the case Future needs to use if it
+#    contains a signal. See emit_refs.py for sample code that demonstrates this
+#    crash and workarounds.
+# #. If the signal is declared in ``Future``, then the it must accept an
+#    ``object`` instead of a ``Future``, sine ``Future`` isn't defined yet.
+#    Awkward, but not a show-stopper.
+class SignalInvoker(QObject):
+    # Emitted to invoke ``g``.
+    doneSignal = pyqtSignal(Future)
+
+    # A method to invoke ``future.g``.
+    def onDoneSignal(self, future):
+        future._g(future)
+#
+# Thread / thread pool worker classes
+# -----------------------------------
+# Neither the ``_AsyncWorker`` class nor the ``AsyncPoolWorker`` class should
+# be instianted by a user of this module; instead, these are used by
+# ``AsyncController`` to run a function in a separate thread.
+class _AsyncPoolWorker(QRunnable):
+    def __init__(self,
+      # The Future instance which contains the callable to invoke.
+      future):
+
+        QRunnable.__init__(self)
+        self._future = future
+
+    # This is invoked by a thread from the thread pool.
+    def run(self):
+        self._future._invoke()
+
+class _AsyncWorker(QObject):
+    # This signal contains the information necessary to run a callable.
+    startSignal = pyqtSignal(Future)
+
+    # The start signal is connected to this slot. It runs ``f`` in the worker
+    # thread.
+    def onStart(self,
+      # The Future instance which contains the callable to invoke.
+      future):
+
+        future._invoke()
+#
+# Demo code
+# =========
+# Print the time and status of a set of tasks, to see how the threads operate.
+class TimePrinter(object):
+    def __init__(self,
+      # A sequence of tasks to monitor.
+      tasks,
+      # QApplication instance, used as a parent for a Qtimer
+      app):
+
+        self.tasks = tasks
+
+        # Current time, in seconds.
+        self.time_sec = 0.0
+
+        # Time between prints, in seconds.
+        self.interval_sec = 0.1
+
+        # Create a timer to continually print the time.
+        self.qt = QTimer(app)
+        self.qt.timeout.connect(self.printTime)
+        self.qt.start(self.interval_sec*1000)
+
+    # Print the time.
+    def printTime(self):
+        sys.stdout.write('{} seconds: task states are '.format(self.time_sec))
+        for task in self.tasks:
+            sys.stdout.write('{}'.format(task.state))
+        sys.stdout.write('.\n')
+        self.time_sec += self.interval_sec
+        self.tasks[3].cancel()
+
+def main():
+    # Create an application.
+    app = QApplication(sys.argv)
+
+    # Define a function ``foo`` to run aysnchronously, calling ``foo_done`` when
+    # it completes.
+    def foo(a, b):
+        print('Foo ' + str(a) + str(b) + ' in thread ' + str(QThread.currentThread()))
+        if a == 3:
+            # As a test, raise an exception. See if a useful traceback is
+            # printed.
+            asdf
+        time.sleep(0.3)
+        return a + 0.1
+    def foo_done(future):
+        print('Done ' + str(future.result) )
+
+    # Run foo using a single thread ('QThread') or a pool of threads (0). Give
+    # it ``app`` as the parent so that when Qt destroys ``app``, it will also
+    # destroy this class.
+    ac = AsyncController(0, app) # ac = AsyncController('QThread', app)
+    task1 = ac.start(foo_done, foo, 1, b=' 2')
+    task2 = ac.start(foo_done, foo, 3, b=' 4')
+    task3 = ac.start(foo_done, foo, 5, b=' 6')
+    task4 = ac.start(foo_done, foo, 7, b=' 8')
+
+    # Print the time and thread status.
+    tp = TimePrinter((task1, task2, task3, task4), app)
+
+    # Exit the program shortly after the event loop starts up.
+    QTimer.singleShot(800, app.exit)
+
+    # Run the main event loop.
+    sys.exit(app.exec_())
+
+if __name__ == '__main__':
+    main()

--- a/enki/lib/future.py
+++ b/enki/lib/future.py
@@ -201,13 +201,11 @@ class AsyncController(QObject):
     # emulates a C++ destructor by freeing resources before the C++ class is
     # destroyed.
     def onParentDestroyed(self):
-        #print('onParentDestroyed')
         self.del_()
 #
 # Destructor
 # """"""""""
-    # In case the above method wasn't called (parent wasn't provided to the
-    # constructor, typically), try to exit gracefully here.
+    # In case the above method wasn't called, try to exit gracefully here.
     def __del__(self):
         self.del_()
 #

--- a/enki/lib/future.py
+++ b/enki/lib/future.py
@@ -406,7 +406,12 @@ class Future(object):
     # emitted when ``f`` finishes will not be.
     def cancel(self, discardResult=False):
         if discardResult:
-            self.signalInvoker.doneSignal.disconnect(self.signalInvoker.onDoneSignal)
+            # If cancel(True) was called before, this raises and exception.
+            # Ignore it.
+            try:
+                self.signalInvoker.doneSignal.disconnect(self.signalInvoker.onDoneSignal)
+            except TypeError:
+                pass
         self._requestCancel = True
 
     # Return the result produced by invoking ``f``, or raise any exception which

--- a/enki/plugins/preview/preview_sync.py
+++ b/enki/plugins/preview/preview_sync.py
@@ -106,10 +106,7 @@ class PreviewSync(QObject):
             #    also been disconnected and canceled. We're safe from any
             #    future calls from the sync job to this thread, which would
             #    cause a crash (this object is destroyed --  don't call it!).
-            try:
-                self._future.signalInvoker.doneSignal.disconnect()
-            except TypeError:
-                pass
+            self._future.signalInvoker.doneSignal.disconnect()
 
     # Vertical synchronization
     ##========================

--- a/enki/plugins/preview/preview_sync.py
+++ b/enki/plugins/preview/preview_sync.py
@@ -10,6 +10,7 @@
 #
 # Imports
 # =======
+import cProfile
 # Third-party
 # -----------
 from PyQt4.QtCore import pyqtSignal, QPoint, Qt, QTimer, QObject, QThread
@@ -53,6 +54,7 @@ class PreviewSync(QObject):
         self.webView = webView
         self._initPreviewToTextSync()
         self._initTextToPreviewSync()
+        self.pr = cProfile.Profile()
 
     def _onJavaScriptCleared(self):
         """This is called before starting a new load of a web page, to inject the
@@ -73,6 +75,7 @@ class PreviewSync(QObject):
     def del_(self):
         # Uninstall the text-to-web sync only if it was installed in the first
         # place (it depends on TRE).
+        self.pr.print_stats()
         if findApproxTextInTarget:
             self._cursorMovementTimer.stop()
             core.workspace().cursorPositionChanged.disconnect(self._onCursorPositionChanged)
@@ -484,6 +487,64 @@ class PreviewSync(QObject):
         qp = core.workspace().currentDocument().qutepart
         # Perform an approximate match between the clicked webpage text and the
         # qutepart text.
+        #
+        # Performance notes: the following line is REALLY slow. Scrolling through
+        # preview.py with profiling enabled produced::
+        #
+        #  Output from Enki:
+        #         41130 function calls in 3.642 seconds
+        #
+        #   Ordered by: standard name
+        #
+        #   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+        #       13    0.000    0.000    0.000    0.000 __init__.py:406(text)
+        #       13    0.000    0.000    3.398    0.261 approx_match.py:138(findApproxText)
+        #       13    0.000    0.000    3.432    0.264 approx_match.py:175(findApproxTextInTarget)
+        #       13    0.029    0.002    0.034    0.003 approx_match.py:252(refineSearchResult)
+        #       26    0.000    0.000    0.000    0.000 core.py:177(workspace)
+        #       13    0.000    0.000    0.000    0.000 dockwidget.py:156(keyPressEvent)
+        #       13    0.000    0.000    0.013    0.001 preview_sync.py:221(_webCursorCoords)
+        #       13    0.001    0.000    0.018    0.001 preview_sync.py:233(_scrollSync)
+        #       13    0.000    0.000    0.206    0.016 preview_sync.py:568(_movePreviewPaneToIndex)
+        #       13    0.000    0.000    0.000    0.000 preview_sync.py:99(_alignScrollAmount)
+        #       26    0.000    0.000    0.000    0.000 workspace.py:380(currentDocument)
+        #       26    0.000    0.000    0.000    0.000 {built-in method currentWidget}
+        #       13    0.000    0.000    0.000    0.000 {built-in method cursorRect}
+        #       13    0.013    0.001    0.013    0.001 {built-in method evaluateJavaScript}
+        #       26    0.119    0.005    0.119    0.005 {built-in method findText}
+        #       52    0.000    0.000    0.000    0.000 {built-in method geometry}
+        #       52    0.000    0.000    0.000    0.000 {built-in method height}
+        #       13    0.000    0.000    0.000    0.000 {built-in method horizontalScrollBar}
+        #       13    0.000    0.000    0.000    0.000 {built-in method isContentEditable}
+        #       13    0.000    0.000    0.000    0.000 {built-in method isVisible}
+        #       13    0.000    0.000    0.000    0.000 {built-in method key}
+        #       52    0.000    0.000    0.000    0.000 {built-in method mainFrame}
+        #       26    0.000    0.000    0.000    0.000 {built-in method mapToGlobal}
+        #       91    0.001    0.000    0.001    0.000 {built-in method page}
+        #       13    0.000    0.000    0.000    0.000 {built-in method position}
+        #       13    0.000    0.000    0.000    0.000 {built-in method scrollBarGeometry}
+        #       13    0.000    0.000    0.000    0.000 {built-in method scrollPosition}
+        #       26    0.001    0.000    0.001    0.000 {built-in method setContentEditable}
+        #       13    0.003    0.000    0.003    0.000 {built-in method setScrollPosition}
+        #       13    0.000    0.000    0.000    0.000 {built-in method stop}
+        #       13    0.000    0.000    0.000    0.000 {built-in method textCursor}
+        #       26    0.007    0.000    0.007    0.000 {built-in method toPlainText}
+        #       26    0.000    0.000    0.000    0.000 {built-in method topLeft}
+        #       13    0.000    0.000    0.000    0.000 {built-in method top}
+        #       26    0.000    0.000    0.000    0.000 {built-in method y}
+        #       26    0.064    0.002    0.064    0.002 {keyClick}
+        #       13    0.000    0.000    0.000    0.000 {keyPressEvent}
+        #      845    0.000    0.000    0.000    0.000 {len}
+        #    38582    0.004    0.000    0.004    0.000 {max}
+        #       13    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
+        #       13    0.000    0.000    0.000    0.000 {method 'groups' of 'tre.Match' objects}
+        #       26    3.397    0.131    3.397    0.131 {method 'search' of 'tre.Pattern' objects}
+        #       26    0.000    0.000    0.000    0.000 {min}
+        #      806    0.000    0.000    0.000    0.000 {range}
+        #       13    0.001    0.000    0.001    0.000 {tre.compile}
+        #
+        # Therefore, finding ways to make this faster or run it in another
+        # thread should significantly speed its operation.
         textIndex = findApproxTextInTarget(tc, webIndex, qp.text)
         # Move the cursor to textIndex in qutepart, assuming corresponding text
         # was found.
@@ -562,6 +623,7 @@ class PreviewSync(QObject):
         per item 3 above. It can also be called when a sync is needed (when
         switching windows, for example).
         """
+        self.pr.enable()
         # Only run this if we TRE is installed.
         if not findApproxTextInTarget:
             return
@@ -638,3 +700,4 @@ class PreviewSync(QObject):
             # Sync the cursors.
             self._scrollSync(True)
             self.textToPreviewSynced.emit()
+            self.pr.disable()

--- a/enki/plugins/preview/preview_sync.py
+++ b/enki/plugins/preview/preview_sync.py
@@ -92,7 +92,10 @@ class PreviewSync(QObject):
             self._ac.del_()
             # Disconnect after del\_, since del\_ guarentees that all threaded
             # tasks are complete; only after that should we disconnect.
+            try:
                 self._future.signalInvoker.doneSignal.disconnect()
+            except TypeError:
+                pass
 
     # Vertical synchronization
     ##========================
@@ -644,6 +647,7 @@ class PreviewSync(QObject):
         txt = mf.toPlainText()
         # Before starting a new sync job, cancel pending ones.
         self._future.cancel()
+        self._future.signalInvoker.doneSignal.disconnect()
         self._future = self._ac.start(self._movePreviewPaneToIndex, findApproxTextInTarget,
                        qp.text, qp.textCursor().position(), txt)
         if cProfile:

--- a/tests/test_core/test_future.py
+++ b/tests/test_core/test_future.py
@@ -402,5 +402,13 @@ class TestAsyncController(unittest.TestCase):
                     ac.start(em.g, f, self.assertEquals, QThread.HighestPriority,
                              _futurePriority=QThread.HighestPriority)
 
+    # Test calling canel twice.
+    def test_15(self):
+        for _ in self.poolAndThread:
+            with AsyncController(_) as ac:
+                future = ac._wrap(None, lambda: None)
+                future.cancel(True)
+                future.cancel(True)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_core/test_future.py
+++ b/tests/test_core/test_future.py
@@ -1,0 +1,350 @@
+# .. -*- coding: utf-8 -*-
+#
+# *****************************************
+# future_test.py - Unit tests for future.py
+# *****************************************
+# To run the tests, invoke ``py.test future_test.py``. Helpful command-line
+# options:
+#
+# -s
+#    Don't capture stdout, instead dump to screen. See `capturing
+#    <http://pytest.org/latest/capture.html>`_.
+#
+# -k name
+#    Run only tests matching name. See `specifying tests
+#    <http://pytest.org/latest/usage.html#specifying-tests-selecting-tests>`_.
+#
+# Imports
+# =======
+import sys
+import os.path
+sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(__file__)), ".."))
+import base
+
+# Library imports
+# ---------------
+from Queue import Queue
+import unittest
+#
+# Third-party imports
+# -------------------
+from PyQt4.QtCore import pyqtSignal, QObject, QTimer, QEventLoop, QThread
+#
+# Local imports
+# -------------
+from enki.lib.future import AsyncController, Future
+#
+# Test helpers
+# ============
+class WaitForSignal(unittest.TestCase):
+    def __init__(self,
+      # The signal to wait for.
+      signal,
+      # The maximum time to wait for the signal to be emitted, in ms.
+      timeoutMs,
+      # True to self.assertif the signal wasn't emitted.
+      assertIfNotRaised=True,
+      # Expected parameters which this signal must supply.
+      expectedSignalParams=None,
+      # True to print exceptions raised in the event loop
+      printExcTraceback=True):
+
+        self.signal = signal
+        self.timeoutMs = timeoutMs
+        self.expectedSignalParams = expectedSignalParams
+        self.assertIfNotRaised = assertIfNotRaised
+        self.printExcTraceback = printExcTraceback
+
+        # Stores the result of comparing self.expectedSignalParams with the
+        # actual params.
+        self.areSenderSignalArgsWrong = False
+        # True if signal was received.
+        self.gotSignal = False
+
+    # Create a slot which receives a senderSignal with any number
+    # of arguments. Check the arguments against their expected
+    # values, if requested, storing the result in senderSignalArgsWrong[0].
+    # (I can't use senderSignalArgsWrong = True/False, since
+    # non-local variables cannot be assigned in another scope).
+    def signalSlot(self, *args):
+        # If the senderSignal args should be checked and they
+        # don't match, then they're wrong. In all other cases,
+        # they're right.
+        if self.expectedSignalParams:
+            self.areSenderSignalArgsWrong = (self.expectedSignalParams != args)
+        # We received the requested signal, so exit the event loop or never
+        # enter it (exit won't exit an event loop that hasn't been run). When
+        # this is nested inside other WaitForSignal clauses, signals may be
+        # received in another QEventLoop, even before this object's QEventLoop
+        # starts.
+        self.qe.exit()
+        self.gotSignal = True
+
+    def __enter__(self):
+        # Create an event loop to run in. Otherwise, we need to use the papp
+        # (QApplication) main loop, which may already be running and therefore
+        # unusable.
+        self.qe = QEventLoop()
+
+        # Connect both signals to a slot which quits the event loop.
+        self.signal.connect(self.signalSlot)
+
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # Create a single-shot timer. Could use QTimer.singleShot(),
+        # but can't cancel this / disconnect it.
+        self.timer = QTimer()
+        self.timer.setSingleShot(True)
+        self.timer.timeout.connect(self.qe.quit)
+        self.timer.start(self.timeoutMs)
+
+        # Catch any exceptions which the EventLoop would otherwise catch
+        # and not re-raise.
+        self.exceptions = None
+        def excepthook(type_, value, tracebackObj):
+            self.exceptions = (value, tracebackObj)
+            if self.printExcTraceback:
+                oldExcHook(type_, value, tracebackObj)
+            self.qe.exit()
+        oldExcHook = sys.excepthook
+        sys.excepthook = excepthook
+
+        # Wait for an emitted signal, unless it already occurred.
+        if not self.gotSignal:
+            self.qe.exec_()
+        # Restore the old exception hook
+        sys.excepthook = oldExcHook
+        # Clean up: don't allow the timer to call app.quit after this
+        # function exits, which would produce "interesting" behavior.
+        ret = self.timer.isActive()
+        self.timer.stop()
+        # Stopping the timer may not cancel timeout signals in the
+        # event queue. Disconnect the signal to be sure that loop
+        # will never receive a timeout after the function exits.
+        # Likewise, disconnect the senderSignal for the same reason.
+        self.signal.disconnect(self.signalSlot)
+        self.timer.timeout.disconnect(self.qe.quit)
+
+        # If an exception occurred in the event loop, re-raise it.
+        if self.exceptions:
+            value, tracebackObj = self.exceptions
+            raise value, None, tracebackObj
+
+        # Check that the signal occurred.
+        self.sawSignal = ret and not self.areSenderSignalArgsWrong
+        if self.assertIfNotRaised:
+            self.assertTrue(self.sawSignal)
+
+        # Don't mask exceptions.
+        return False
+
+# A helper class to signal when its method function is executed.
+class Emitter(QObject):
+    bing = pyqtSignal()
+
+    def __init__(self, expected=None, assertEquals=None):
+        QObject.__init__(self)
+        self.expected = expected
+        self.assertEquals = assertEquals
+
+    def g(self, future):
+        self.bing.emit()
+        self.thread = QThread.currentThread()
+        self.result = future.result
+        if self.expected:
+            self.assertEquals(self.expected, self.result)
+
+# Emit a signal afte receiving three unique signals.
+class SignalCombiner(QObject):
+    allEmitted = pyqtSignal()
+
+    def __init__(self):
+        QObject.__init__(self)
+        self.s = set()
+
+    def onBing(self):
+        assert self.sender()
+        self.s.add(self.sender())
+        if len(self.s) == 3:
+            self.allEmitted.emit()
+
+#
+# Unit tests
+# ==========
+class TestAsyncController(unittest.TestCase):
+    # Tuples of AsyncController params to test over.
+    l = ('QThread', 0, 1, 4)
+    m = (0, 1, 4)
+
+    # Verify that a test function is run.
+    def test_1(self):
+        for _ in self.l:
+            with AsyncController(_) as ac:
+                # gotHere must be a list in order to f to change it in a way that is
+                # visible outside of f.
+                gotHere = [False]
+                def f():
+                    gotHere[0] = True
+                future = ac._wrap(None, f)
+                with WaitForSignal(future.signalInvoker.doneSignal, 1000):
+                    ac._start(future)
+                self.assertTrue(gotHere[0])
+
+    # Verify that the result function is run.
+    def test_2(self):
+        for _ in self.l:
+            with AsyncController(_) as ac:
+                em = Emitter(2, self.assertEquals)
+                with WaitForSignal(em.bing, 1000):
+                    ac.start(em.g, lambda: 2)
+
+    # Verify that a result from f is passed to g.
+    def test_3(self):
+        for _ in self.l:
+            with AsyncController(_) as ac:
+                em = Emitter(123, self.assertEquals)
+                with WaitForSignal(em.bing, 1000):
+                    ac.start(em.g, lambda x: x + 2, 121)
+
+    # Verify that correct arguments are passed to f.
+    def test_4(self):
+        for _ in self.l:
+            with AsyncController(_) as ac:
+                def f(a, b, c=2, d=4):
+                    self.assertEquals(a, 2)
+                    self.assertEquals(b, 3)
+                    self.assertEquals(c, 4)
+                    self.assertEquals(d, 5)
+                em = Emitter()
+                with WaitForSignal(em.bing, 1000):
+                    ac.start(em.g, f, 2, 3, d=5, c=4)
+
+    # Verify that f actually runs in a separate thread.
+    def test_5(self):
+        for _ in self.l:
+            with AsyncController(_) as ac:
+                def f(currentThread):
+                    self.assertNotEquals(currentThread, QThread.currentThread())
+                em = Emitter()
+                with WaitForSignal(em.bing, 1000):
+                    ac.start(em.g, f, QThread.currentThread())
+
+    # Verify that f actually runs in separate pooled threads.
+    def test_6(self):
+        # Don't test with one pooled thread -- this test expects at least two
+        # threads.
+        for _ in (0, 4):
+            with AsyncController(_) as ac:
+                q = Queue()
+                def f():
+                    q.get()
+                    return QThread.currentThread()
+                em1 = Emitter()
+                em2 = Emitter()
+                ac.start(em1.g, f)
+                ac.start(em2.g, f)
+                with WaitForSignal(em1.bing, 1000), WaitForSignal(em2.bing, 1000):
+                    q.put(None)
+                    q.put(None)
+                s = set([em1.result, em2.result, QThread.currentThread()])
+                self.assertEquals(len(s), 3)
+
+    # Verify that the correct functions and callbacks get executed.
+    def test_7(self):
+        with AsyncController('QThread') as ac:
+            em1 = Emitter(15, self.assertEquals)
+            em2 = Emitter(16, self.assertEquals)
+            em3 = Emitter(17, self.assertEquals)
+            ac.start(em1.g, lambda: 15)
+            ac.start(em2.g, lambda: 16)
+            future3 = ac._wrap(em3.g, lambda: 17)
+            with WaitForSignal(em3.bing, 1000):
+                ac._start(future3)
+
+    # Verify that the correct functions and callbacks get executed in a pool.
+    def test_8(self):
+        for _ in self.m:
+            with AsyncController(_) as ac:
+                q1 = Queue()
+                q2 = Queue()
+                q3 = Queue()
+                em1 = Emitter(15, self.assertEquals)
+                em2 = Emitter(16, self.assertEquals)
+                em3 = Emitter(17, self.assertEquals)
+                future1 = ac.start(em1.g, lambda: q1.get())
+                future2 = ac.start(em2.g, lambda: q2.get())
+                future3 = ac.start(em3.g, lambda: q3.get())
+                sc = SignalCombiner()
+                em1.bing.connect(sc.onBing)
+                em2.bing.connect(sc.onBing)
+                em3.bing.connect(sc.onBing)
+                with WaitForSignal(sc.allEmitted, 1000):
+                    q1.put(15)
+                    q2.put(16)
+                    q3.put(17)
+
+    # Verify that exceptions get propogated correctly.
+    def test_9(self):
+        for _ in self.l:
+            with AsyncController(_) as ac:
+                def f():
+                    raise TypeError
+                em = Emitter()
+                with self.assertRaises(TypeError), WaitForSignal(em.bing, 1000):
+                    ac.start(em.g, f)
+
+    # Verify that if ``f`` is launched in a thread, ``g`` will be run in that
+    # same thread.
+    def test_10(self):
+        with AsyncController('QThread') as ac:
+            em2 = Emitter()
+            def f2():
+                future2 = ac.start(em2.g, lambda x: x, QThread.currentThread())
+            with WaitForSignal(em2.bing, 1000):
+                ac.start(None, f2)
+            self.assertEquals(em2.thread, em2.result)
+
+    # Verify that if ``f`` is launched in a thread, ``g`` will be run in that
+    # same thread. (For thread pools).
+    def test_11(self):
+        # Don't test with one pooled thread -- this test expects at least two
+        # threads.
+        for _ in (0, 4):
+            with AsyncController(_) as ac:
+                em2 = Emitter()
+                def f2():
+                    future = ac.start(em2.g, lambda x: x, QThread.currentThread())
+                    # The doneSignal won't be processed without an event loop. A
+                    # thread pool doesn't create one, so make our own to run ``g``.
+                    qe = QEventLoop()
+                    future.signalInvoker.doneSignal.connect(qe.exit)
+                    qe.exec_()
+                with WaitForSignal(em2.bing, 1000):
+                    ac.start(None, f2)
+                self.assertEquals(em2.thread, em2.result)
+
+    # Verify that job status and cancelation works.
+    def test_12(self):
+        for _ in self.l:
+            with AsyncController(_) as ac:
+                q1a = Queue()
+                q1b = Queue()
+                def f1():
+                    q1b.put(None)
+                    q1a.get()
+                em1 = Emitter()
+                future1 = ac.start(em1.g, f1)
+                q1b.get()
+                self.assertEquals(future1.state, Future.STATE_RUNNING)
+
+                future2 = ac.start(None, lambda: None)
+                self.assertEquals(future2.state, Future.STATE_WAITING)
+                with WaitForSignal(em1.bing, 1000):
+                    future2.cancel()
+                    q1a.put(None)
+                self.assertEquals(future1.state, Future.STATE_FINISHED)
+                self.assertEquals(future2.state, Future.STATE_CANCELED)
+                
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_core/test_future.py
+++ b/tests/test_core/test_future.py
@@ -177,12 +177,14 @@ class SignalCombiner(QObject):
 # ==========
 class TestAsyncController(unittest.TestCase):
     # Tuples of AsyncController params to test over.
-    l = ('QThread', 0, 1, 4)
-    m = (0, 1, 4)
+    poolAndThread = ('QThread', 0, 1, 4)
+    poolOnly = (0, 1, 4)
+    singleThreadOnly = ('QThread', 1)
+    multipleThreadsOnly = (0, 4)
 
     # Verify that a test function is run.
     def test_1(self):
-        for _ in self.l:
+        for _ in self.poolAndThread:
             with AsyncController(_) as ac:
                 # gotHere must be a list in order to f to change it in a way that is
                 # visible outside of f.
@@ -196,7 +198,7 @@ class TestAsyncController(unittest.TestCase):
 
     # Verify that the result function is run.
     def test_2(self):
-        for _ in self.l:
+        for _ in self.poolAndThread:
             with AsyncController(_) as ac:
                 em = Emitter(2, self.assertEquals)
                 with WaitForSignal(em.bing, 1000):
@@ -204,7 +206,7 @@ class TestAsyncController(unittest.TestCase):
 
     # Verify that a result from f is passed to g.
     def test_3(self):
-        for _ in self.l:
+        for _ in self.poolAndThread:
             with AsyncController(_) as ac:
                 em = Emitter(123, self.assertEquals)
                 with WaitForSignal(em.bing, 1000):
@@ -212,7 +214,7 @@ class TestAsyncController(unittest.TestCase):
 
     # Verify that correct arguments are passed to f.
     def test_4(self):
-        for _ in self.l:
+        for _ in self.poolAndThread:
             with AsyncController(_) as ac:
                 def f(a, b, c=2, d=4):
                     self.assertEquals(a, 2)
@@ -225,7 +227,7 @@ class TestAsyncController(unittest.TestCase):
 
     # Verify that f actually runs in a separate thread.
     def test_5(self):
-        for _ in self.l:
+        for _ in self.poolAndThread:
             with AsyncController(_) as ac:
                 def f(currentThread):
                     self.assertNotEquals(currentThread, QThread.currentThread())
@@ -237,7 +239,7 @@ class TestAsyncController(unittest.TestCase):
     def test_6(self):
         # Don't test with one pooled thread -- this test expects at least two
         # threads.
-        for _ in (0, 4):
+        for _ in self.multipleThreadsOnly:
             with AsyncController(_) as ac:
                 q = Queue()
                 def f():
@@ -267,7 +269,7 @@ class TestAsyncController(unittest.TestCase):
 
     # Verify that the correct functions and callbacks get executed in a pool.
     def test_8(self):
-        for _ in self.m:
+        for _ in self.poolOnly:
             with AsyncController(_) as ac:
                 q1 = Queue()
                 q2 = Queue()
@@ -289,7 +291,7 @@ class TestAsyncController(unittest.TestCase):
 
     # Verify that exceptions get propogated correctly.
     def test_9(self):
-        for _ in self.l:
+        for _ in self.poolAndThread:
             with AsyncController(_) as ac:
                 def f():
                     raise TypeError
@@ -313,7 +315,7 @@ class TestAsyncController(unittest.TestCase):
     def test_11(self):
         # Don't test with one pooled thread -- this test expects at least two
         # threads.
-        for _ in (0, 4):
+        for _ in self.multipleThreadsOnly:
             with AsyncController(_) as ac:
                 em2 = Emitter()
                 def f2():
@@ -329,7 +331,7 @@ class TestAsyncController(unittest.TestCase):
 
     # Verify that job status and cancelation works.
     def test_12(self):
-        for _ in ('QThread', 1):
+        for _ in self.singleThreadOnly:
             with AsyncController(_) as ac:
                 q1a = Queue()
                 q1b = Queue()
@@ -353,7 +355,7 @@ class TestAsyncController(unittest.TestCase):
 
     # Verify that job status and cancelation works.
     def test_13(self):
-        for _ in ('QThread', 1):
+        for _ in self.singleThreadOnly:
             with AsyncController(_) as ac:
                 q1a = Queue()
                 q1b = Queue()

--- a/tests/test_core/test_future.py
+++ b/tests/test_core/test_future.py
@@ -373,5 +373,22 @@ class TestAsyncController(unittest.TestCase):
                 # make sure neither happened.
                 time.sleep(0.1)
 
+    # Test per-task priority.
+    def test_14(self):
+        for _ in self.poolAndThread:
+            with AsyncController(_) as ac:
+                def f(assertEquals, priority):
+                    assertEquals(QThread.currentThread().priority(), priority)
+                em = Emitter()
+                ac.defaultPriority = QThread.LowPriority
+                with WaitForSignal(em.bing, 1000):
+                    ac.start(em.g, f, self.assertEquals, QThread.LowestPriority,
+                             _futurePriority=QThread.LowestPriority)
+                with WaitForSignal(em.bing, 1000):
+                    ac.start(em.g, f, self.assertEquals, QThread.LowPriority)
+                with WaitForSignal(em.bing, 1000):
+                    ac.start(em.g, f, self.assertEquals, QThread.HighestPriority,
+                             _futurePriority=QThread.HighestPriority)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_core/test_future.py
+++ b/tests/test_core/test_future.py
@@ -363,15 +363,25 @@ class TestAsyncController(unittest.TestCase):
                     q1b.put(None)
                     q1a.get()
                 # Cancel future3 while it's running in the other thread.
-                em3 = Emitter('should never be called', self.assertEquals)
-                em3.bing.connect(self.fail)
-                future3 = ac.start(em3.g, f1)
+                em1 = Emitter('should never be called', self.assertEquals)
+                em1.bing.connect(self.fail)
+                future1 = ac.start(em1.g, f1)
                 q1b.get()
-                future3.cancel(True)
+                future1.cancel(True)
                 q1a.put(None)
-                # It should never emit a signal or invoke its callback. Wait to
-                # make sure neither happened.
+                # If the result is discarded, it should never emit a signal or
+                # invoke its callback, even if the task is already running. Wait
+                # to make sure neither happened.
                 time.sleep(0.1)
+
+                # In addition, the signal from a finished task that is discarded
+                # should not invoke the callback, even after the task has
+                # finihsed and the sigal emitted.
+                em2 = Emitter('should never be called', self.assertEquals)
+                em2.bing.connect(self.fail)
+                future2 = ac.start(em2.g, lambda: None)
+                time.sleep(0.1)
+                future2.cancel(True)
 
     # Test per-task priority.
     def test_14(self):

--- a/tests/test_core/test_future.py
+++ b/tests/test_core/test_future.py
@@ -367,6 +367,7 @@ class TestAsyncController(unittest.TestCase):
                 em1.bing.connect(self.fail)
                 future1 = ac.start(em1.g, f1)
                 q1b.get()
+                self.assertEquals(future1.state, Future.STATE_RUNNING)
                 future1.cancel(True)
                 q1a.put(None)
                 # If the result is discarded, it should never emit a signal or
@@ -381,6 +382,7 @@ class TestAsyncController(unittest.TestCase):
                 em2.bing.connect(self.fail)
                 future2 = ac.start(em2.g, lambda: None)
                 time.sleep(0.1)
+                self.assertEquals(future2.state, Future.STATE_FINISHED)
                 future2.cancel(True)
 
     # Test per-task priority.

--- a/tests/test_plugins/test_preview.py
+++ b/tests/test_plugins/test_preview.py
@@ -52,6 +52,14 @@ def requiresModule(module):
         return unittest.skip("This test requires python-{}".format(module))
     return lambda func: func
 
+# Decorating each test function which needs it with
+# @base.requiresCmdlineUtility('sphinx-build --version')
+# makes the tests slow: using
+# ``python -m profile -s cumtime test_preview_sync.py`` showed almost
+# 7 seconds spend running this command. So, run it once here then re-use
+# this value.
+requiresSphinx = base.requiresCmdlineUtility('sphinx-build --version')
+
 
 class PreviewTestCase(base.TestCase):
     """A class of utilities used to aid in testing the preview module."""
@@ -141,7 +149,7 @@ class Test(PreviewTestCase):
         with self.assertRaisesRegexp(AssertionError, 'Dock Previe&w not found'):
             self._dock()
 
-    @base.requiresCmdlineUtility('sphinx-build --version')
+    @requiresSphinx
     def test_emptySphinxDocument(self):
         core.config()['Sphinx']['Enabled'] = True
         core.workspace().createEmptyNotSavedDocument()
@@ -255,7 +263,7 @@ class Test(PreviewTestCase):
         self.assertTrue(sw.labelCodeChatIntro.isEnabled())
         sw.close()
 
-    @base.requiresCmdlineUtility('sphinx-build --version')
+    @requiresSphinx
     def test_settingUiCheck3a(self):
         """test_uiCheck1a has tested the case when Sphinx is disabled. This
         unit test will test the case when Sphinx is mannually enabled.
@@ -318,7 +326,7 @@ class Test(PreviewTestCase):
         # call self._dock()
         #self._dock()
 
-    @base.requiresCmdlineUtility('sphinx-build --version')
+    @requiresSphinx
     @base.inMainLoop
     def test_previewCheck2(self):
         """Basic Sphinx test: create a Sphinx project in a temp folder, return
@@ -331,7 +339,7 @@ head
 content"""
         webViewContent, logContent = self._doBasicSphinxTest('rst')
 
-    @base.requiresCmdlineUtility('sphinx-build --version')
+    @requiresSphinx
     @base.inMainLoop
     def test_previewCheck2a(self):
         """Basic Sphinx test. Output directory is an absolute directory
@@ -345,7 +353,7 @@ head
 content"""
         webViewContent, logContent = self._doBasicSphinxTest('rst')
 
-    @base.requiresCmdlineUtility('sphinx-build --version')
+    @requiresSphinx
     @requiresModule('CodeChat')
     @base.inMainLoop
     def test_previewCheck3a(self):
@@ -365,7 +373,7 @@ content"""
         self.assertTrue(u'<p>content</p>' in webViewContent)
         self.assertTrue(u'Processing code.py to code.py.rst' in logContent)
 
-    @base.requiresCmdlineUtility('sphinx-build --version')
+    @requiresSphinx
     @requiresModule('CodeChat')
     @base.inMainLoop
     def test_previewCheck3(self):
@@ -392,7 +400,7 @@ content"""
         with self.assertRaisesRegexp(AssertionError, 'Dock Previe&w not found'):
             self._dock()
 
-    @base.requiresCmdlineUtility('sphinx-build --version')
+    @requiresSphinx
     @base.inMainLoop
     def test_previewCheck5(self):
         """Basic Sphinx test: with Sphinx and codechat disabled, no preview
@@ -419,7 +427,7 @@ content"""
         self._doBasicTest('py')
         self.assertEqual(self._plainText(), self.testText)
 
-    @base.requiresCmdlineUtility('sphinx-build --version')
+    @requiresSphinx
     @base.inMainLoop
     def test_previewCheck6a(self):
         """Empty code file produces a Sphinx failure since file in toctree should
@@ -440,7 +448,7 @@ content"""
         # preview dock is not empty. A '\n' is added accordingly.
         self.assertEqual(self._plainText(), self.testText + '\n')
 
-    @base.requiresCmdlineUtility('sphinx-build --version')
+    @requiresSphinx
     @base.inMainLoop
     def test_previewCheck7a(self):
         """Unicode string passed to Sphinx should be handled properly.
@@ -469,7 +477,7 @@ content"""
         assert 'test' in self._html()
 
 
-    @base.requiresCmdlineUtility('sphinx-build --version')
+    @requiresSphinx
     @base.inMainLoop
     def test_previewCheck8a(self):
         """Start with Sphinx disabled, make sure rst file will be rendered by
@@ -505,7 +513,7 @@ content"""
         self._doBasicTest('rst')
         self.assertTrue("""Unknown directive type "wrong".""" in self._logText())
 
-    @base.requiresCmdlineUtility('sphinx-build --version')
+    @requiresSphinx
     @base.inMainLoop
     def test_previewCheck9a(self):
         """Test Sphinx error can be captured correctly"""
@@ -543,7 +551,7 @@ content"""
         self.assertTrue(u'Енки' in self._logText())
 
     @unittest.skip("Unicode isn't presented in the log window")
-    @base.requiresCmdlineUtility('sphinx-build --version')
+    @requiresSphinx
     @base.inMainLoop
     def test_previewCheck12(self):
         """Unicode in log window while in Sphinx mode does not work since Sphinx
@@ -635,7 +643,7 @@ head
         self.assertEqual(self._widget().prgStatus.styleSheet(), 'QProgressBar::chunk {}')
         self.assertEqual(self._logText(), '')
 
-    @base.requiresCmdlineUtility('sphinx-build --version')
+    @requiresSphinx
     @requiresModule('CodeChat')
     @base.inMainLoop
     def test_previewCheck19(self):
@@ -657,7 +665,7 @@ head
         self.assertTrue(u'<p>content</p>' in webViewContent)
         self.assertTrue(u'Processing code.py to code.py.rst' in logContent)
 
-    @base.requiresCmdlineUtility('sphinx-build --version')
+    @requiresSphinx
     @requiresModule('CodeChat')
     @base.inMainLoop
     def test_previewCheck20(self):
@@ -682,7 +690,7 @@ head
         self.assertTrue(u'<p>content</p>' in webViewContent)
         self.assertTrue(u'Processing code.py to code.py.rst' in logContent)
 
-    @base.requiresCmdlineUtility('sphinx-build --version')
+    @requiresSphinx
     @requiresModule('CodeChat')
     @base.inMainLoop
     def test_previewCheck20a(self):
@@ -711,7 +719,7 @@ head
         self.assertTrue(u'<p>content</p>' in webViewContent)
         self.assertTrue(u'Processing code.py to code.py.rst' in logContent)
 
-    @base.requiresCmdlineUtility('sphinx-build --version')
+    @requiresSphinx
     @requiresModule('CodeChat')
     @base.inMainLoop
     def test_previewCheck21(self):
@@ -734,7 +742,7 @@ head
         self._assertHtmlReady(lambda: None, timeout = 10000)
         self.assertTrue(u'Unknown interpreted text role "doc"' in self._logText())
 
-    @base.requiresCmdlineUtility('sphinx-build --version')
+    @requiresSphinx
     def test_previewCheck22(self):
         """ Assume codechat is not installed, render a .rst file using
         restructuredText and then render using sphinx.
@@ -751,7 +759,7 @@ head
             self.assertTrue(u"document isn't included in any toctree" in self._logText())
             self.assertTrue('#FF9955' in self._widget().prgStatus.styleSheet())
 
-    @base.requiresCmdlineUtility('sphinx-build --version')
+    @requiresSphinx
     def test_previewCheck23(self):
         """If the document is modified externally, then build on save will be
         automatically enabled. Calling scheduledocumentprocessing will not

--- a/tests/test_plugins/test_preview_sync.py
+++ b/tests/test_plugins/test_preview_sync.py
@@ -204,7 +204,7 @@ class Test(PreviewTestCase):
         # The sync won't happen until the timer expires; wait
         # for that.
         self.assertEmits(lambda: self._dock().previewSync._moveTextPaneToIndex(index, False),
-          self._dock().previewSync._cursorMovementTimer.timeout, 350)
+          self._dock().previewSync.textToPreviewSynced, 350)
         # The web view should have the line containing s selected now.
         if checkText:
             self.assertTrue(s in self._widget().webView.selectedText())
@@ -225,13 +225,10 @@ class Test(PreviewTestCase):
 
     # More complex test to web sync
     ##^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    @unittest.expectedFailure
     @requiresModule('docutils')
     def test_sync12(self):
-        """Tables with an embedded image cause findText to fail. Make sure no
-        exceptions are raised.
-
-        I can't seem to find a workaround to this: what search text does findText
-        expect when a table + embedded image are involved?
+        """Tables with an embedded image cause findText to fail.
         """
         self._textToWeb('table', """
 ================  ========================

--- a/win/enki_install.sh
+++ b/win/enki_install.sh
@@ -22,7 +22,11 @@ cd enki_all
 
 # TRE
 # ===
-$INSTALL git build-essential autotools-dev automake gettext libtool autopoint zip python-dev python-setuptools
+$INSTALL git build-essential autotools-dev automake gettext libtool autopoint zip python-dev python-pip
+# Upgrade pip first.
+sudo pip install -U pip
+# Then install Python packages from pip, since apt-get packages are older.
+sudo pip install -U setuptools
 # See https://github.com/bjones1/tre.
 git clone https://github.com/bjones1/tre.git
 cd tre
@@ -36,7 +40,7 @@ sudo make install
 $PAUSE
 cd python
 sudo python setup.py install
-# Note: the line below should be added to your .bashrc,
+# Note: the line below should be added to your .bashrc.
 export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 $PAUSE
 cd ../..
@@ -64,8 +68,9 @@ cd ..
 
 # Enki
 # ====
-$INSTALL desktop-file-utils exuberant-ctags python-pyparsing python-markdown python-sphinx python-pip pylint
-sudo pip install mock
+$INSTALL desktop-file-utils exuberant-ctags
+# Then install Python packages from pip, since apt-get packages are older.
+sudo pip install -U mock pyparsing markdown sphinx pylint
 # See https://github.com/bjones1/enki.
 git clone https://github.com/bjones1/enki.git
 cd enki


### PR DESCRIPTION
I've noticed that when the preview window is open and the source document is long, cursor movement / typing gets very slow because the sync is taking forever. This runs the preview sync in a background thread. You must recompile TRE to see any differences, since the old TRE doesn't release the GIL during a search operation.

On a side note, this includes a AsyncController class, which encapsulates running a function in a worker thread. It's a cross between some of the QtConcurrent classes (QtConcurrent::run, plus QFuture and QFutureWatcher) that PyQt doesn't have.