### PR TITLE
Allow overriding session.json from ENKI_SESSION

### DIFF
--- a/enki/main.py
+++ b/enki/main.py
@@ -171,6 +171,9 @@ def _parseCommandLine():
 
     parser.add_option("-n", "--no-session", dest="no_session", action="store_true",
                       help="Do not restore session")
+    
+    parser.add_option("-s", "--session", dest="session_name", action="store",
+                      help="Session name or file, overrides ENKI_SESSION environment variable")
 
     parser.add_option("-p", "--profiling", dest="profiling", action="store_true",
                       help="profile initialization and exit. For developers")
@@ -178,6 +181,7 @@ def _parseCommandLine():
     (options, args) = parser.parse_args()
 
     cmdLine = {"profiling" : options.profiling,
+               "session_name": options.session_name,
                "no-session" : options.no_session}
 
     # Parse +N spec.

--- a/enki/plugins/session.py
+++ b/enki/plugins/session.py
@@ -12,13 +12,15 @@ from enki.core.defines import CONFIG_DIR
 import enki.core.json_wrapper
 
 def getSessionFilePath():
-    session_envvar = os.environ.get("ENKI_SESSION");
-    # assuming environment variable values are secure
-    if not session_envvar:
+    session_name = core.commandLineArgs().get("session_name")
+    if not session_name:
+        session_name = os.environ.get("ENKI_SESSION")
+    # assuming session_name value is secure
+    if not session_name:
         return os.path.join(CONFIG_DIR, 'session.json')
-    if '/' not in session_envvar:
-        return os.path.join(CONFIG_DIR, 'session_%s.json' % session_envvar)
-    return session_envvar;
+    if '/' not in session_name:
+        return os.path.join(CONFIG_DIR, 'session_%s.json' % session_name)
+    return session_name;
 
 _SESSION_FILE_PATH = getSessionFilePath()
 


### PR DESCRIPTION
If ENKI_SESSION is set and contains a slash, this file is used as
session file.
If ENKI_SESSION is set, but does not contain '/', the
"session_%s.json" is used.
If ENKI_SESSION is unset, the usual "session.json" is used.