### PR TITLE
Sphinx version

### DIFF
--- a/enki/plugins/preview/__init__.py
+++ b/enki/plugins/preview/__init__.py
@@ -114,16 +114,15 @@ def _getSphinxVersion(path):
     Raise OSError if not found, or
           ValueError if failed to parse.
     """
-    stdout, stderr = get_console_output(path)
-    for line in stderr.split('\n'):
-        if line.startswith("Sphinx"):
-            # Typical line we're looking for, taking from running
-            # ``sphinx-build`` on the command line: ``Sphinx v1.2.3``.
-            # Therefore, ``line.split()[1][1:] == '1.2.3'``.
-            version = line.split()[1][1:]
-            # Split on periods and convert to an int, returning the version as a
-            # tuple.
-            return [int(num) for num in version.split('.')]
+    stdout, stderr = get_console_output([path, "--version"])
+    # Command "Sphinx-build --version" will only output one line. Typical
+    # output looks like: ``Sphinx (sphinx-build) 1.2.3``.
+    # Therefore, ``line.split()[2] == '1.2.3'``.
+    if stdout.startswith("Sphinx"):
+        version = stdout.split()[2]
+        # Split on periods and convert to an int, returning the version as a
+        # tuple.
+        return [int(num) for num in version.split('.')]
     raise ValueError
 
 class SettingsWidget(QWidget):

--- a/enki/plugins/preview/__init__.py
+++ b/enki/plugins/preview/__init__.py
@@ -124,9 +124,12 @@ def _getSphinxVersion(path):
     out = stdout + '\n' + stderr
     for line in out.split('\n'):
         if line.startswith("Sphinx"):
-            # Split on periods and convert to an int, returning the version as a
+            # Split on space, take the last segment, if it starts with character
+            # 'v', strip the 'v'. Then split on dot. returning the version as a
             # tuple.
-            return [int(num) for num in line[-5:].split('.')]
+            version = line.split(' ')[-1]
+            version = version[1:] if version.startswith('v') else version
+            return [int(num) for num in version.split('.')]
     raise ValueError
 
 class SettingsWidget(QWidget):

--- a/enki/plugins/preview/__init__.py
+++ b/enki/plugins/preview/__init__.py
@@ -115,14 +115,18 @@ def _getSphinxVersion(path):
           ValueError if failed to parse.
     """
     stdout, stderr = get_console_output([path, "--version"])
-    # Command "Sphinx-build --version" will only output one line. Typical
-    # output looks like: ``Sphinx (sphinx-build) 1.2.3``.
-    # Therefore, ``line.split()[2] == '1.2.3'``.
-    if stdout.startswith("Sphinx"):
-        version = stdout.split()[2]
-        # Split on periods and convert to an int, returning the version as a
-        # tuple.
-        return [int(num) for num in version.split('.')]
+    # Command "Sphinx-build --version" will only output sphinx version info.
+    # Typical output looks like: ``Sphinx (sphinx-build) 1.2.3`` or
+    # ``Sphinx v1.2.3``
+    # But the problem is sometimes version info goes to stdout(version 1.2.3), while
+    # sometimes it goes to stderr(version 1.1.3). Thus combining stdout and
+    # stderr is necessary.
+    out = stdout + '\n' + stderr
+    for line in out.split('\n'):
+        if line.startswith("Sphinx"):
+            # Split on periods and convert to an int, returning the version as a
+            # tuple.
+            return [int(num) for num in line[-5:].split('.')]
     raise ValueError
 
 class SettingsWidget(QWidget):

--- a/tests/test_plugins/test_preview.py
+++ b/tests/test_plugins/test_preview.py
@@ -1181,17 +1181,32 @@ head
 
     @mock.patch('enki.plugins.preview.get_console_output')
     def test_getSphinxVersion3(self, mock_gca):
-        """Check that _getSphinxVersion raises an exception if the Sphinx
-        version info isn't present."""
+        """Check that _getSphinxVersion complies to sphinx version 1.1.3"""
         mock_gca.return_value = ("stderr", \
-"""Error: Insufficient arguments.
-
-Sphinx v1.2.3
+"""Sphinx v1.1.3
 Usage: C:\Python27\Scripts\sphinx-build [options] sourcedir outdir [filenames...
 ]
 """)
         self.assertEqual(_getSphinxVersion('anything_since_replaced_by_mock'),
+                         [1, 1, 3])
+
+    @mock.patch('enki.plugins.preview.get_console_output')
+    def test_getSphinxVersion4(self, mock_gca):
+        """Check that _getSphinxVersion complies to sphinx version 1.2.3"""
+        mock_gca.return_value = ("stderr", \
+"""Sphinx (sphinx-build) 1.2.3
+""")
+        self.assertEqual(_getSphinxVersion('anything_since_replaced_by_mock'),
                          [1, 2, 3])
+
+    @mock.patch('enki.plugins.preview.get_console_output')
+    def test_getSphinxVersion5(self, mock_gca):
+        """Check that _getSphinxVersion complies to sphinx version 1.3.1"""
+        mock_gca.return_value = ("stdout", \
+"""Sphinx (sphinx-build) 1.3.1
+""")
+        self.assertEqual(_getSphinxVersion('anything_since_replaced_by_mock'),
+                         [1, 3, 1])
 
     def test_zoom(self):
         webView = self._widget().webView


### PR DESCRIPTION
Due to different sphinx versions have different output upon calling ``sphinx-build --version``, old function ``_getSphinxVersion`` only covers sphinx version 1.1.3. Now the ``_getSphinxVersion`` has been rewritten to accommodate sphinx version 1.1.3, 1.2.3 and 1.3.1. Test cases have been created and verified.