### PR TITLE
Fix: Exceptions are already propagated correctly. 

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -69,11 +69,6 @@ def _processPendingEvents():
     timer.timeout.disconnect(qe.quit)
 
 
-# By default, the traceback for excpetions occurring inside
-# an exec_ loop will be printed.
-PRINT_EXEC_TRACKBACK = True
-
-
 def inMainLoop(func, *args):
     """Decorator executes test method in the QApplication main loop.
     QAction shortcuts doesn't work, if main loop is not running.
@@ -105,8 +100,6 @@ def inMainLoop(func, *args):
         exceptions = []
         def excepthook(type_, value, tracebackObj):
             exceptions.append((value, tracebackObj))
-            if PRINT_EXEC_TRACKBACK and not 'ExpectedFailure' in str(type(value)):
-                oldExcHook(type_, value, tracebackObj)
             self.app.exit()
         oldExcHook = sys.excepthook
         sys.excepthook = excepthook
@@ -445,8 +438,6 @@ def waitForSignal(sender, senderSignal, timeoutMs, expectedSignalParams=None):
     exceptions = []
     def excepthook(type_, value, tracebackObj):
         exceptions.append((value, tracebackObj))
-        if PRINT_EXEC_TRACKBACK:
-            oldExcHook(type_, value, tracebackObj)
     oldExcHook = sys.excepthook
     sys.excepthook = excepthook
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -124,12 +124,7 @@ class TestWaitForSignal(unittest.TestCase):
     def test_11(self):
         ts = TestSignal()
         with self.assertRaises(AssertionError):
-            oldVal = base.PRINT_EXEC_TRACKBACK
-            base.PRINT_EXEC_TRACKBACK = False
-            try:
-                base.waitForSignal(lambda: self.fail(), ts.testSignal, 100)
-            finally:
-                base.PRINT_EXEC_TRACKBACK = oldVal
+            base.waitForSignal(lambda: self.fail(), ts.testSignal, 100)
 
 
 # inMainLoop
@@ -143,12 +138,7 @@ class TestInMainLoop(base.TestCase):
     # Make sure exceptions inMainLoop get propagated.
     def test_1(self):
         with self.assertRaises(AssertionError):
-            oldVal = base.PRINT_EXEC_TRACKBACK
-            base.PRINT_EXEC_TRACKBACK = False
-            try:
-                self._failInMainLoop()
-            finally:
-                base.PRINT_EXEC_TRACKBACK = oldVal
+            self._failInMainLoop()
 
 # Main
 # ====


### PR DESCRIPTION
Remove unnecessary print which simply confuse the issue (see https://github.com/bjones1/enki/issues/41, for example).