### PR TITLE
Add -S option to auto-derive session name from pwd

### DIFF
--- a/enki/main.py
+++ b/enki/main.py
@@ -173,6 +173,9 @@ def _parseCommandLine():
     parser.add_option("-s", "--session", dest="session_name", action="store",
                       help="Session name or file, overrides ENKI_SESSION environment variable")
 
+    parser.add_option("-S", "--auto-session", dest="auto_session", action="store_true",
+                      help="Use current directory name as session name")
+
     parser.add_option("-p", "--profiling", dest="profiling", action="store_true",
                       help="profile initialization and exit. For developers")
 
@@ -180,6 +183,7 @@ def _parseCommandLine():
 
     cmdLine = {"profiling": options.profiling,
                "session_name": options.session_name,
+               "auto-session-name": options.auto_session,
                "no-session": options.no_session}
 
     # Parse +N spec.

--- a/enki/plugins/session.py
+++ b/enki/plugins/session.py
@@ -17,6 +17,8 @@ _AUTO_SAVE_INTERVAL_MS = 60 * 1000
 def getSessionFilePath():
     if core.commandLineArgs()['session_name']:
         session_name = core.commandLineArgs()['session_name']
+    elif core.commandLineArgs()['auto-session-name']:
+        session_name = os.getcwd().split(os.path.sep)[-1]
     elif 'ENKI_SESSION' in os.environ:
         session_name = os.environ['ENKI_SESSION']
     else:


### PR DESCRIPTION
I got tired of starting enki as

```
project1$ enki -s project1
myotherproject$ enki -s myotherproject
```

and implemented option to automate this.

Currently it is based on v15.11.1 (master fails for me now: something about Qt5 vs Qt4).

Are you interested in the feature (so I try to prepare it for master) or it shall be another dangling patch for rebasing?