### PR TITLE
Propose the current filename in the SaveAs dialogue - issue #416

### DIFF
--- a/enki/core/document.py
+++ b/enki/core/document.py
@@ -391,7 +391,11 @@ class Document(QWidget):
     def saveFileAs(self):
         """Ask for new file name with dialog. Save file
         """
-        path, _ = QFileDialog.getSaveFileName(self, self.tr('Save file as...'))
+        if self._filePath:
+            default_filename = os.path.basename(self._filePath)
+        else:
+            default_filename = ''
+        path, _ = QFileDialog.getSaveFileName(self, self.tr('Save file as...'), default_filename)
         if not path:
             return
 


### PR DESCRIPTION
Proposes the current filename in the SaveAs dialogue, in order to use it when saving on another folder, leaves it blank if it is a new file.